### PR TITLE
Add Solang as binary

### DIFF
--- a/contracts/solidity/compile_test.sol
+++ b/contracts/solidity/compile_test.sol
@@ -1,0 +1,3 @@
+contract compile_test {
+    function test() public pure {}
+}

--- a/contracts/solidity/computation.sol
+++ b/contracts/solidity/computation.sol
@@ -1,0 +1,14 @@
+contract Computation {
+    function triangle_number(int64 n) public pure {
+        int64 sum = 0;
+        for (int64 x = 1; x <= n; x++) {
+            sum += x;
+        }
+    }
+
+    function odd_product(int32 n) public pure returns (int64 prod) {
+        for (int32 x = 1; x <= n; x++) {
+            prod *= 2 * int64(x) - 1;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub use drink_riscv as drink;
 pub use drink_wasm as drink;
 pub mod drink_api;
 pub mod ink;
+pub mod solang;

--- a/src/solang.rs
+++ b/src/solang.rs
@@ -9,7 +9,12 @@ use contract_build::Target;
 /// Builds the Solidity source in `path_to_source_sol`.
 /// Returns the path to the build output directory.
 ///
-/// Note: For RiscV the produced contract blob will still have the `.wasm` file extension.
+/// For each each contract found in the source code, solang creates two files:
+/// - `contract_name.wasm`: The code blob.
+/// - `contract_name.contract`: The full contract artifact including metadata.
+/// Where `contract_name` is equal to the name of that contract
+///
+/// Note: For RiscV the produced contract blob does still have the `.wasm` file extension.
 pub fn build_contract<P>(path_to_source_sol: P, target: Target) -> anyhow::Result<PathBuf>
 where
     P: AsRef<Path> + Copy,

--- a/src/solang.rs
+++ b/src/solang.rs
@@ -1,0 +1,80 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use contract_build::Target;
+
+/// Builds the Solidity source in `path_to_source_sol`.
+/// Returns the path to the build output directory.
+///
+/// Note: For RiscV the produced contract blob will still have the `.wasm` file extension.
+pub fn build_contract<P>(path_to_source_sol: P, target: Target) -> anyhow::Result<PathBuf>
+where
+    P: AsRef<Path> + Copy,
+{
+    let target = match target {
+        Target::RiscV => "polkadot-riscv",
+        Target::Wasm => "polkadot",
+    };
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let bin_path = PathBuf::from(manifest_dir).join("bin").join("solang");
+
+    let out_dir = path_to_source_sol
+        .as_ref()
+        .parent()
+        .expect("source file is not in root dir");
+
+    match Command::new(&bin_path)
+        .arg("compile")
+        .arg("--target")
+        .arg(target)
+        .arg("-O")
+        .arg("aggressive")
+        .arg("--release")
+        .arg("--wasm-opt")
+        .arg("z")
+        .arg("-o")
+        .arg(out_dir)
+        .arg(path_to_source_sol.as_ref())
+        .output()
+    {
+        Ok(output) if output.status.success() => Ok(out_dir.to_path_buf()),
+        Ok(output) => Err(anyhow::anyhow!("Failed to compile contract:\n {output:?}")),
+        Err(msg) => Err(anyhow::anyhow!("Failed to execute {bin_path:?}: {msg:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    fn can_compile(target: contract_build::Target) {
+        let path = PathBuf::from("contracts/solidity/compile_test");
+
+        super::build_contract(&path.with_extension("sol"), target).unwrap();
+
+        let len = fs::read(path.with_extension("wasm"))
+            .expect("compiler should produce a contract blob")
+            .len();
+        assert!(len > 0, "compiler should produce a non-empty contract blob");
+
+        let _ = std::fs::remove_file(path.with_extension("wasm"));
+        let _ = std::fs::remove_file(path.with_extension("contract"));
+    }
+
+    #[cfg(feature = "wasm")]
+    #[test]
+    fn can_compile_wasm() {
+        can_compile(contract_build::Target::Wasm)
+    }
+
+    #[cfg(feature = "riscv")]
+    #[test]
+    fn can_compile_riscv() {
+        can_compile(contract_build::Target::RiscV)
+    }
+}


### PR DESCRIPTION
Adding a static `solang` binary. In the long run we want to concider using solang as a library like we do with `ink!`, however it is current blocked. `contract-build` depends on `wasm-opt =0.116`, but `wasm-opt >0.114` introduce namespace conflicts with LLVM when used with other other crates depending on LLVM. This needs to be properly fixed in `wasm-opt` and / or solang (ideally `llvm-sys`) first.