### PR TITLE
Update solang

### DIFF
--- a/contracts/ink/computation/lib.rs
+++ b/contracts/ink/computation/lib.rs
@@ -13,8 +13,8 @@ pub mod computation {
         }
 
         #[ink(message)]
-        pub fn triangle_number(&self, n: i64) {
-            let _res: i64 = (1..=n).fold(0, |sum, x| sum.wrapping_add(x));
+        pub fn triangle_number(&self, n: i64) -> i64 {
+            (1..=n).fold(0, |sum, x| sum.wrapping_add(x))
         }
 
         #[ink(message)]

--- a/contracts/solidity/Computation.sol
+++ b/contracts/solidity/Computation.sol
@@ -1,6 +1,5 @@
 contract Computation {
-    function triangle_number(int64 n) public pure {
-        int64 sum = 0;
+    function triangle_number(int64 n) public pure returns (int64 sum) {
         for (int64 x = 1; x <= n; x++) {
             sum += x;
         }

--- a/contracts/solidity/Computation.sol
+++ b/contracts/solidity/Computation.sol
@@ -1,13 +1,19 @@
 contract Computation {
     function triangle_number(int64 n) public pure returns (int64 sum) {
-        for (int64 x = 1; x <= n; x++) {
-            sum += x;
+        unchecked {
+            for (int64 x = 1; x <= n; x++) {
+                sum += x;
+            }
         }
     }
 
-    function odd_product(int32 n) public pure returns (int64 prod) {
-        for (int32 x = 1; x <= n; x++) {
-            prod *= 2 * int64(x) - 1;
+    function odd_product(int32 n) public pure returns (int64) {
+        unchecked {
+            int64 prod = 1;
+            for (int32 x = 1; x <= n; x++) {
+                prod *= 2 * int64(x) - 1;
+            }
+            return prod;
         }
     }
 }

--- a/src/solang.rs
+++ b/src/solang.rs
@@ -6,10 +6,10 @@ use std::{
 
 use crate::{
     drink::runtime::{AccountIdFor, MinimalRuntime},
+    drink::Weight,
     drink_api::{CallArgs, CreateArgs, DrinkApi},
 };
 use contract_build::Target;
-use drink_wasm::Weight;
 use parity_scale_codec::Encode;
 use subxt_signer::sr25519::dev;
 


### PR DESCRIPTION
- Update solang binary to match `polkavm` in `polkadot-sdk/at/riscv`
- All `computation` methods should always return the computed value. This rules out the compiler optimizing it away as that variable is never read. It didn't influence the benchmark but just in case.
- `wrapping_*` math equals `unchecked` in Solidity. This will make the benchmark fair against `ink!` and also prevent overflowing and early aborting the `odd_product` Solidity benchmark.
- Fix minor issue to make it compile