### PR TITLE
Rearrange groups and multiple `n`s for computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ harness = false
 
 [features]
 default = []
+evm = []
 wasm = [
     "drink-wasm",
 ]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,3 @@ Running (RISC-V and WASM):
 cargo bench --features riscv
 cargo bench --features wasm
 ```
-
-:warning: **Note**: The RISC-V backend is currently not working in native, so the numbers
-are not currently representative. :warning:

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -21,7 +21,7 @@ macro_rules! ink_contract_bench {
 
             let mut group = c.benchmark_group(stringify!($message));
             group.sample_size(30);
-            group.measurement_time(std::time::Duration::from_secs(20));
+            group.measurement_time(std::time::Duration::from_secs(23));
 
             for args in $args {
                 let message = contract.$message(args);

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -11,17 +11,17 @@ macro_rules! ink_contract_bench {
 
             let contract_name = stringify!($name);
 
-            let mut ink_drink = InkDrink::<DefaultEnvironment, MinimalRuntime>::new();
-            let contract = ink_drink.build_and_instantiate::<_, $contract, _, _>(
-                &format!("contracts/ink/{}/Cargo.toml", contract_name),
-                &mut $contract_ref::new(),
-            );
-
             let mut group = c.benchmark_group(stringify!($message));
             group.sample_size(30);
             group.measurement_time(std::time::Duration::from_secs(23));
 
             for args in $args {
+                let mut ink_drink = InkDrink::<DefaultEnvironment, MinimalRuntime>::new();
+                let contract = ink_drink.build_and_instantiate::<_, $contract, _, _>(
+                    &format!("contracts/ink/{}/Cargo.toml", contract_name),
+                    &mut $contract_ref::new(),
+                );
+
                 let message = contract.$message(args);
                 let call_args = CallArgs::from_call_builder(dev::alice(), &message);
 

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -20,12 +20,13 @@ macro_rules! ink_contract_bench {
             let message = contract.$message($args);
             let call_args = CallArgs::from_call_builder(dev::alice(), &message);
 
-            let mut group = c.benchmark_group(contract_name);
+            let group_name = format!("{}_{}", stringify!($message), stringify!($args));
+
+            let mut group = c.benchmark_group(group_name);
             group.sample_size(30);
+            group.measurement_time(std::time::Duration::from_secs(20));
 
-            let bench_name = format!("{}_{}", stringify!($message), stringify!($args));
-
-            group.bench_function(bench_name, |b| {
+            group.bench_function("ink", |b| {
                 b.iter(|| ink_drink.drink.call(call_args.clone()).unwrap())
             });
 

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -17,8 +17,6 @@ macro_rules! ink_contract_bench {
                 &mut $contract_ref::new(),
             );
 
-            // let group_name = format!("{}_{}", stringify!($message), stringify!($args));
-
             let mut group = c.benchmark_group(stringify!($message));
             group.sample_size(30);
             group.measurement_time(std::time::Duration::from_secs(23));

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -34,20 +34,20 @@ macro_rules! ink_contract_bench {
     };
 }
 
-ink_contract_bench!(crypto, Crypto, CryptoRef, sha3, 100);
+ink_contract_bench!(crypto, Crypto, CryptoRef, sha3, 1000);
 ink_contract_bench!(
     computation,
     Computation,
     ComputationRef,
     odd_product,
-    100_000
+    1000000
 );
 ink_contract_bench!(
     computation,
     Computation,
     ComputationRef,
     triangle_number,
-    100_000
+    1000000
 );
 
 criterion_group!(benches, sha3, odd_product, triangle_number);

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -26,7 +26,10 @@ macro_rules! ink_contract_bench {
             group.sample_size(30);
             group.measurement_time(std::time::Duration::from_secs(20));
 
-            group.bench_function("ink", |b| {
+            let target = schlau::target_str();
+            let bench_name = format!("ink_{}", target);
+
+            group.bench_function(bench_name, |b| {
                 b.iter(|| ink_drink.drink.call(call_args.clone()).unwrap())
             });
 

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -108,8 +108,8 @@ fn remainders(c: &mut Criterion) {
     let mut group = c.benchmark_group("remainders");
     group.sample_size(20);
 
-    bench_solang(&mut group, "Arithmetics", "remainders", &args_scale);
     bench_evm(&mut group, "Arithmetics", "remainders", &args_evm);
+    bench_solang(&mut group, "Arithmetics", "remainders", &args_scale);
 
     group.finish()
 }

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -84,7 +84,7 @@ fn odd_product(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("odd_product");
     group.sample_size(30);
-    group.measurement_time(Duration::from_secs(25));
+    group.measurement_time(Duration::from_secs(40));
 
     bench_solang(&mut group, "Computation", "odd_product", &ns);
     bench_evm(&mut group, "Computation", "odd_product", &ns_evm);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -62,7 +62,7 @@ fn triangle_number(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("triangle_number");
     group.sample_size(30);
-    group.measurement_time(Duration::from_secs(25));
+    group.measurement_time(Duration::from_secs(40));
 
     bench_solang(&mut group, "Computation", "triangle_number", &ns);
     bench_evm(&mut group, "Computation", "triangle_number", &ns_evm);
@@ -71,7 +71,7 @@ fn triangle_number(c: &mut Criterion) {
 }
 
 fn odd_product(c: &mut Criterion) {
-    let ns = [100_000i32, 200_000, 400_000, 800_000, 1_600_000].map(|n| (n, n.to_string()));
+    let ns = [100_000i32, 200_000, 400_000, 800_000].map(|n| (n, n.to_string()));
     let ns_evm = ns
         .clone()
         .map(|(n, display)| {

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -14,17 +14,19 @@ fn bench_evm(
     message: &str,
     args: &[(Vec<DynSolValue>, String)],
 ) {
-    for (args, parameter) in args {
-        let mut evm_contract = EvmContract::init(contract);
+    if cfg!(feature = "evm") {
+        for (args, parameter) in args {
+            let mut evm_contract = EvmContract::init(contract);
 
-        let args = evm_contract.call_args(message, args);
-        let id = BenchmarkId::new("evm", parameter);
+            let args = evm_contract.call_args(message, args);
+            let id = BenchmarkId::new("evm", parameter);
 
-        group.bench_function(id, |b| {
-            b.iter(|| {
-                evm_contract.sandbox.call(args.clone()).unwrap();
-            })
-        });
+            group.bench_function(id, |b| {
+                b.iter(|| {
+                    evm_contract.sandbox.call(args.clone()).unwrap();
+                })
+            });
+        }
     }
 }
 

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -93,17 +93,23 @@ fn odd_product(c: &mut Criterion) {
 }
 
 fn remainders(c: &mut Criterion) {
-    let args_scale = &[sp_core::U256::from(1), sp_core::U256::from(2)];
-    let args_evm = &[
-        DynSolValue::Uint(U256::from(1), 256),
-        DynSolValue::Uint(U256::from(2), 256),
-    ];
+    let args_scale = [(
+        [sp_core::U256::from(1), sp_core::U256::from(2)],
+        "(1, 2)".to_owned(),
+    )];
+    let args_evm = [(
+        vec![
+            DynSolValue::Uint(U256::from(1), 256),
+            DynSolValue::Uint(U256::from(2), 256),
+        ],
+        "(1, 2)".to_owned(),
+    )];
 
     let mut group = c.benchmark_group("remainders");
     group.sample_size(20);
 
-    bench_solang(&mut group, "Arithmetics", "remainders", args_scale);
-    bench_evm(&mut group, "Arithmetics", "remainders", args_evm);
+    bench_solang(&mut group, "Arithmetics", "remainders", &args_scale);
+    bench_evm(&mut group, "Arithmetics", "remainders", &args_evm);
 
     group.finish()
 }

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -18,10 +18,7 @@ fn bench_evm(
 
     let args = evm_contract.call_args(message, args);
 
-    let target = schlau::target_str();
-    let bench_name = format!("evm_{}", target);
-
-    group.bench_function(bench_name, |b| {
+    group.bench_function("evm", |b| {
         b.iter(|| {
             evm_contract.sandbox.call(args.clone()).unwrap();
         })
@@ -54,7 +51,7 @@ fn triangle_number(c: &mut Criterion) {
 
     let mut group = c.benchmark_group(format!("triangle_number_{}", n));
     group.sample_size(30);
-    group.measurement_time(Duration::from_secs(20));
+    group.measurement_time(Duration::from_secs(25));
 
     bench_solang(&mut group, "Computation", "triangle_number", n);
     bench_evm(&mut group, "Computation", "triangle_number", &[n_evm]);
@@ -68,7 +65,7 @@ fn odd_product(c: &mut Criterion) {
 
     let mut group = c.benchmark_group(format!("odd_product_{}", n));
     group.sample_size(30);
-    group.measurement_time(Duration::from_secs(20));
+    group.measurement_time(Duration::from_secs(25));
 
     bench_solang(&mut group, "Computation", "odd_product", n);
     bench_evm(&mut group, "Computation", "odd_product", &[n_evm]);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -64,8 +64,8 @@ fn triangle_number(c: &mut Criterion) {
     group.sample_size(30);
     group.measurement_time(Duration::from_secs(40));
 
-    bench_solang(&mut group, "Computation", "triangle_number", &ns);
     bench_evm(&mut group, "Computation", "triangle_number", &ns_evm);
+    bench_solang(&mut group, "Computation", "triangle_number", &ns);
 
     group.finish()
 }
@@ -86,8 +86,8 @@ fn odd_product(c: &mut Criterion) {
     group.sample_size(30);
     group.measurement_time(Duration::from_secs(40));
 
-    bench_solang(&mut group, "Computation", "odd_product", &ns);
     bench_evm(&mut group, "Computation", "odd_product", &ns_evm);
+    bench_solang(&mut group, "Computation", "odd_product", &ns);
 
     group.finish()
 }

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -18,7 +18,10 @@ fn bench_evm(
 
     let args = evm_contract.call_args(message, args);
 
-    group.bench_function("evm", |b| {
+    let target = schlau::target_str();
+    let bench_name = format!("evm_{}", target);
+
+    group.bench_function(bench_name, |b| {
         b.iter(|| {
             evm_contract.sandbox.call(args.clone()).unwrap();
         })
@@ -35,7 +38,10 @@ fn bench_solang<Args: Encode>(
 
     let args = solang_contract.call_args(message, args);
 
-    group.bench_function("solang", |b| {
+    let target = schlau::target_str();
+    let bench_name = format!("solang_{}", target);
+
+    group.bench_function(bench_name, |b| {
         b.iter(|| {
             solang_contract.drink_api.call(args.clone()).unwrap();
         })

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -6,6 +6,7 @@ use alloy_dyn_abi::DynSolValue;
 use alloy_primitives::I256;
 use parity_scale_codec::Encode;
 use schlau::{evm::EvmContract, solang::SolangContract};
+use std::time::Duration;
 
 fn bench_evm(
     group: &mut BenchmarkGroup<WallTime>,
@@ -42,11 +43,12 @@ fn bench_solang<Args: Encode>(
 }
 
 fn triangle_number(c: &mut Criterion) {
-    let n = 100_000i64;
+    let n = 1_000_000i64;
     let n_evm = DynSolValue::Int(I256::try_from(n).unwrap(), 64);
 
     let mut group = c.benchmark_group(format!("triangle_number_{}", n));
-    group.sample_size(20);
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(20));
 
     bench_solang(&mut group, "Computation", "triangle_number", n);
     bench_evm(&mut group, "Computation", "triangle_number", &[n_evm]);
@@ -55,11 +57,12 @@ fn triangle_number(c: &mut Criterion) {
 }
 
 fn odd_product(c: &mut Criterion) {
-    let n = 100_000i32;
+    let n = 1_000_000i32;
     let n_evm = DynSolValue::Int(I256::try_from(n).unwrap(), 32);
 
     let mut group = c.benchmark_group(format!("odd_product_{}", n));
-    group.sample_size(20);
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(20));
 
     bench_solang(&mut group, "Computation", "odd_product", n);
     bench_evm(&mut group, "Computation", "odd_product", &[n_evm]);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -14,9 +14,9 @@ fn bench_evm(
     message: &str,
     args: &[(Vec<DynSolValue>, String)],
 ) {
-    let mut evm_contract = EvmContract::init(contract);
-
     for (args, parameter) in args {
+        let mut evm_contract = EvmContract::init(contract);
+
         let args = evm_contract.call_args(message, args);
         let id = BenchmarkId::new("evm", parameter);
 
@@ -34,9 +34,9 @@ fn bench_solang<Args: Encode>(
     message: &str,
     args: &[(Args, String)],
 ) {
-    let mut solang_contract = SolangContract::init(contract);
-
     for (args, parameter) in args {
+        let mut solang_contract = SolangContract::init(contract);
+
         let args = solang_contract.call_args(message, args);
         let id = BenchmarkId::new(&format!("solang({})", schlau::target_str()), parameter);
 

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -49,7 +49,7 @@ fn bench_solang<Args: Encode>(
 }
 
 fn triangle_number(c: &mut Criterion) {
-    let ns = [100_000i64, 200_000, 400_000, 800_000, 1_600_000].map(|n| (n, n.to_string()));
+    let ns = [100_000i64, 200_000, 400_000, 800_000].map(|n| (n, n.to_string()));
     let ns_evm = ns
         .clone()
         .map(|(n, display)| {

--- a/src/ink.rs
+++ b/src/ink.rs
@@ -58,13 +58,7 @@ where
         <Contract as ContractCallBuilder>::Type: FromAccountId<E>,
         Args: Encode + Clone,
     {
-        let target = if cfg!(feature = "wasm") {
-            Target::Wasm
-        } else if cfg!(feature = "riscv") {
-            Target::RiscV
-        } else {
-            panic!("No VM target feature enabled")
-        };
+        let target = crate::target();
         let build_result = build_contract(contract, target).expect("Error building contract");
         let code = std::fs::read(build_result).expect("Error loading contract");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use contract_build::Target;
+
 #[cfg(feature = "riscv")]
 pub use drink_riscv as drink;
 #[cfg(feature = "wasm")]
@@ -7,3 +9,20 @@ pub mod evm;
 pub mod ink;
 pub mod solang;
 pub mod solc;
+
+pub const fn target() -> Target {
+    if cfg!(feature = "wasm") {
+        Target::Wasm
+    } else if cfg!(feature = "riscv") {
+        Target::RiscV
+    } else {
+        panic!("No VM target feature enabled")
+    }
+}
+
+pub const fn target_str() -> &'static str {
+    match target() {
+        Target::Wasm => "wasm",
+        Target::RiscV => "riscv",
+    }
+}

--- a/src/solang.rs
+++ b/src/solang.rs
@@ -100,13 +100,7 @@ pub fn build_and_load_contract<P>(path_to_source_sol: P) -> anyhow::Result<Build
 where
     P: AsRef<Path> + Copy,
 {
-    let target = if cfg!(feature = "wasm") {
-        Target::Wasm
-    } else if cfg!(feature = "riscv") {
-        Target::RiscV
-    } else {
-        panic!("No VM target feature enabled")
-    };
+    let target = crate::target();
     let out_dir = build_contract(path_to_source_sol, target)?;
     let contract_name = path_to_source_sol
         .as_ref()

--- a/src/solang.rs
+++ b/src/solang.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     path::{Path, PathBuf},
     process::Command,
 };

--- a/src/solang.rs
+++ b/src/solang.rs
@@ -67,9 +67,7 @@ where
         Target::Wasm => "polkadot",
     };
 
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let bin_path = PathBuf::from(manifest_dir).join("bin").join("solang");
+    let bin_path = PathBuf::from("bin").join("solang");
 
     let out_dir = path_to_source_sol
         .as_ref()

--- a/src/solc.rs
+++ b/src/solc.rs
@@ -1,6 +1,5 @@
 use alloy_json_abi::JsonAbi;
 use std::{
-    env,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -11,9 +10,7 @@ pub fn build_contract<P>(path_to_source_sol: P) -> anyhow::Result<BuildResult>
 where
     P: AsRef<Path> + Copy,
 {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
-
-    let bin_path = PathBuf::from(manifest_dir).join("bin").join("solc");
+    let bin_path = PathBuf::from("bin").join("solc");
 
     let abi_str =
         run_and_extract_output(path_to_source_sol, &bin_path, "--abi", "Contract JSON ABI")?;


### PR DESCRIPTION
Update the benchmark groups/ids to allow easy comparison, also do multiple runs per operation with different params, which could be increased in a stepwise fashion.

To produce tables do:
```bash
# prerequisites
cargo install cargo-criterion
cargo install criterion-table

# run benchmarks
cargo criterion --features riscv --bench evm,solidity --message-format=json > solidity_riscv.json
cargo criterion --features wasm --bench solidity --message-format=json > solidity_wasm.json

# produce table
cat solidity_riscv.json solidity_wasm.json | criterion-table
```

## Benchmark Results

### odd_product

|              | `evm`                     | `solang(riscv)`                  | `solang(wasm)`                    |
|:-------------|:--------------------------|:---------------------------------|:--------------------------------- |
| **`100000`** | `66.16 ms` (✅ **1.00x**)  | `25.85 ms` (🚀 **2.56x faster**)  | `95.29 ms` (❌ *1.44x slower*)     |
| **`200000`** | `130.44 ms` (✅ **1.00x**) | `20.74 ms` (🚀 **6.29x faster**)  | `191.36 ms` (❌ *1.47x slower*)    |
| **`400000`** | `263.07 ms` (✅ **1.00x**) | `16.15 ms` (🚀 **16.29x faster**) | `380.37 ms` (❌ *1.45x slower*)    |
| **`800000`** | `522.06 ms` (✅ **1.00x**) | `22.05 ms` (🚀 **23.67x faster**) | `760.23 ms` (❌ *1.46x slower*)    |

### triangle_number

|              | `evm`                     | `solang(riscv)`                 | `solang(wasm)`                    |
|:-------------|:--------------------------|:--------------------------------|:--------------------------------- |
| **`100000`** | `49.23 ms` (✅ **1.00x**)  | `75.00 ms` (❌ *1.52x slower*)   | `37.27 ms` (✅ **1.32x faster**)   |
| **`200000`** | `99.27 ms` (✅ **1.00x**)  | `58.99 ms` (✅ **1.68x faster**) | `16.53 ms` (🚀 **6.01x faster**)   |
| **`400000`** | `199.88 ms` (✅ **1.00x**) | `59.01 ms` (🚀 **3.39x faster**) | `11.25 ms` (🚀 **17.76x faster**)  |
| **`800000`** | `388.41 ms` (✅ **1.00x**) | `38.91 ms` (🚀 **9.98x faster**) | `15.56 ms` (🚀 **24.97x faster**)  |

### remainders

|              | `evm`                     | `solang(riscv)`                 | `solang(wasm)`                     |
|:-------------|:--------------------------|:--------------------------------|:---------------------------------- |
| **`(1, 2)`** | `241.93 us` (✅ **1.00x**) | `6.95 ms` (❌ *28.73x slower*)   | `60.58 ms` (❌ *250.41x slower*)    |

This PR has just focused on producing a way to create multiple benchmarks per call and summarizing into a table for easy consumption. It does not focus on interpreting the results etc, as there are some results which are curious and need diving deeper into.
