### PR TITLE
`ink!` benchmark numbers

### DIFF
--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -45,7 +45,7 @@ ink_contract_bench!(
     Computation,
     ComputationRef,
     odd_product,
-    [100_000, 200_000, 400_000, 800_000]
+    [2_000_000, 4_000_000, 8_000_000]
 );
 ink_contract_bench!(
     computation,

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -23,7 +23,8 @@ macro_rules! ink_contract_bench {
                 );
 
                 let message = contract.$message(args);
-                let call_args = CallArgs::from_call_builder(dev::alice(), &message);
+                let call_args =
+                    CallArgs::from_call_builder(dev::alice(), &message).with_max_gas_limit();
 
                 let parameter = args.to_string();
                 let id = BenchmarkId::new(&format!("ink({})", schlau::target_str()), parameter);
@@ -38,7 +39,7 @@ macro_rules! ink_contract_bench {
     };
 }
 
-ink_contract_bench!(crypto, Crypto, CryptoRef, sha3, [100, 200, 400, 800]);
+ink_contract_bench!(crypto, Crypto, CryptoRef, sha3, [2000, 4000, 8000]);
 ink_contract_bench!(
     computation,
     Computation,

--- a/contracts/ink/computation/lib.rs
+++ b/contracts/ink/computation/lib.rs
@@ -14,13 +14,21 @@ pub mod computation {
 
         #[ink(message)]
         pub fn triangle_number(&self, n: i64) -> i64 {
-            (1..=n).fold(0, |sum, x| sum.wrapping_add(x))
+            let mut sum: i64 = 0;
+            for x in 1..=n {
+                sum = sum.wrapping_add(x);
+            }
+            sum
         }
 
         #[ink(message)]
         #[allow(clippy::arithmetic_side_effects)]
         pub fn odd_product(&self, n: i32) -> i64 {
-            (1..=n).fold(1, |prod, x| prod.wrapping_mul(2 * x as i64 - 1))
+            let mut prod: i64 = 1;
+            for x in 1..=n {
+                prod = prod.wrapping_mul(2 * x as i64 - 1);
+            }
+            prod
         }
     }
 }

--- a/src/drink_api.rs
+++ b/src/drink_api.rs
@@ -203,6 +203,10 @@ where
         self.gas_limit = Some(gas_limit);
         self
     }
+
+    pub fn with_max_gas_limit(self) -> Self {
+        self.with_gas_limit(Weight::from_parts(u64::MAX, u64::MAX))
+    }
 }
 
 fn keypair_to_account<AccountId: From<[u8; 32]>>(keypair: &Keypair) -> AccountId {


### PR DESCRIPTION
Attempt to get some meaningful numbers for comparing `ink` pure execution on `riscv` vs `wasm`. Previously the `n` was too low to show any meaningful difference because the actual execution time was only a small percentage of the total time which includes some "start-up" time.

Also for `triangle_number` for whatever reason, no matter how big I made `n` it never increased in execution time...changing from `fold` to a loop fixed this. Maybe compiler optimizing away the calculation...?

Run with:
```bash
cargo criterion --features wasm --bench ink --message-format=json > ink_wasm.json
cargo criterion --features riscv --bench ink --message-format=json > ink_riscv.json
cat ink_wasm.json ink_riscv.json | criterion-table
```

## Benchmark Results

### sha3

|            | `ink(wasm)`               | `ink(riscv)`                      |
|:-----------|:--------------------------|:--------------------------------- |
| **`2000`** | `54.73 ms` (✅ **1.00x**)  | `6.61 ms` (🚀 **8.27x faster**)    |
| **`4000`** | `109.10 ms` (✅ **1.00x**) | `10.05 ms` (🚀 **10.85x faster**)  |
| **`8000`** | `218.19 ms` (✅ **1.00x**) | `18.60 ms` (🚀 **11.73x faster**)  |

### odd_product

|               | `ink(wasm)`               | `ink(riscv)`                      |
|:--------------|:--------------------------|:--------------------------------- |
| **`2000000`** | `55.73 ms` (✅ **1.00x**)  | `6.29 ms` (🚀 **8.87x faster**)    |
| **`4000000`** | `112.55 ms` (✅ **1.00x**) | `8.74 ms` (🚀 **12.88x faster**)   |
| **`8000000`** | `225.59 ms` (✅ **1.00x**) | `16.26 ms` (🚀 **13.87x faster**)  |

### triangle_number

|                | `ink(wasm)`               | `ink(riscv)`                      |
|:---------------|:--------------------------|:--------------------------------- |
| **`5000000`**  | `127.30 ms` (✅ **1.00x**) | `9.31 ms` (🚀 **13.68x faster**)   |
| **`10000000`** | `256.41 ms` (✅ **1.00x**) | `29.68 ms` (🚀 **8.64x faster**)   |
| **`20000000`** | `509.16 ms` (✅ **1.00x**) | `34.69 ms` (🚀 **14.68x faster**)  |

