### PR TITLE
produce meaningful numbers for computation benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,31 @@
 
 Benchmarking smart contract execution. German cousin of `smart-bench` :brain:
 
-Running (RISC-V and WASM):
+## Running Benchmarks
+
+### Install Prerequisites
 
 ```bash
-cargo bench --features riscv
-cargo bench --features wasm
+cargo install cargo-criterion
+cargo install criterion-table
+````
+
+### Run Solidity Benchmarks
+
+```bash
+# run benchmarks
+cargo criterion --features evm,wasm --bench solidity --message-format=json > solidity_wasm.json
+cargo criterion --features riscv --bench solidity --message-format=json > solidity_riscv.json
+# construct table
+cat solidity_wasm.json solidity_riscv.json | criterion-table
+```
+
+### Run `ink!` Benchmarks
+
+```bash
+# run benchmarks
+cargo criterion --features wasm --bench ink --message-format=json > ink_wasm.json
+cargo criterion --features riscv --bench ink --message-format=json > ink_riscv.json
+# construct table
+cat ink_wasm.json ink_riscv.json | criterion-table
 ```

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -13,7 +13,6 @@ macro_rules! ink_contract_bench {
 
             let mut group = c.benchmark_group(stringify!($message));
             group.sample_size(30);
-            group.measurement_time(std::time::Duration::from_secs(23));
 
             for args in $args {
                 let mut ink_drink = InkDrink::<DefaultEnvironment, MinimalRuntime>::new();
@@ -52,7 +51,7 @@ ink_contract_bench!(
     Computation,
     ComputationRef,
     triangle_number,
-    [100_000, 200_000, 400_000, 800_000]
+    [5_000_000, 10_000_000, 20_000_000]
 );
 
 criterion_group!(benches, sha3, odd_product, triangle_number);

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -51,7 +51,7 @@ ink_contract_bench!(
     Computation,
     ComputationRef,
     triangle_number,
-    [5_000_000, 10_000_000, 20_000_000]
+    [3_000_000, 6_000_000, 12_000_000]
 );
 
 criterion_group!(benches, sha3, odd_product, triangle_number);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -125,7 +125,7 @@ fn remainders(c: &mut Criterion) {
     group.finish()
 }
 
-criterion_group!(computation, triangle_number);
-// criterion_group!(arithmetics, remainders);
+criterion_group!(computation, odd_product, triangle_number);
+criterion_group!(arithmetics, remainders);
 
 criterion_main!(computation);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -9,7 +9,6 @@ use schlau::{
     evm::{EvmContract, ACCOUNTS},
     solang::SolangContract,
 };
-use std::time::Duration;
 
 fn bench_evm(
     group: &mut BenchmarkGroup<WallTime>,
@@ -60,7 +59,7 @@ fn bench_solang<Args: Encode>(
 }
 
 fn triangle_number(c: &mut Criterion) {
-    let ns = [1_000_000i64, 2_000_000, 4_000_000].map(|n| (n, n.to_string()));
+    let ns = [3_000_000i64, 6_000_000, 12_000_000].map(|n| (n, n.to_string()));
     let ns_evm = ns
         .clone()
         .map(|(n, display)| {
@@ -73,7 +72,6 @@ fn triangle_number(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("triangle_number");
     group.sample_size(30);
-    group.measurement_time(Duration::from_secs(40));
 
     bench_evm(&mut group, "Computation", "triangle_number", &ns_evm);
     bench_solang(&mut group, "Computation", "triangle_number", &ns);
@@ -82,7 +80,7 @@ fn triangle_number(c: &mut Criterion) {
 }
 
 fn odd_product(c: &mut Criterion) {
-    let ns = [500_000, 1_000_000, 2_000_000].map(|n| (n, n.to_string()));
+    let ns = [2_000_000i32, 4_000_000, 8_000_000].map(|n| (n, n.to_string()));
     let ns_evm = ns
         .clone()
         .map(|(n, display)| {
@@ -95,7 +93,6 @@ fn odd_product(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("odd_product");
     group.sample_size(30);
-    group.measurement_time(Duration::from_secs(40));
 
     bench_evm(&mut group, "Computation", "odd_product", &ns_evm);
     bench_solang(&mut group, "Computation", "odd_product", &ns);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -60,7 +60,7 @@ fn bench_solang<Args: Encode>(
 }
 
 fn triangle_number(c: &mut Criterion) {
-    let ns = [100_000i64, 200_000, 400_000, 800_000].map(|n| (n, n.to_string()));
+    let ns = [1_000_000i64, 2_000_000, 4_000_000].map(|n| (n, n.to_string()));
     let ns_evm = ns
         .clone()
         .map(|(n, display)| {
@@ -125,7 +125,7 @@ fn remainders(c: &mut Criterion) {
     group.finish()
 }
 
-criterion_group!(computation, odd_product, triangle_number);
-criterion_group!(arithmetics, remainders);
+criterion_group!(computation, triangle_number);
+// criterion_group!(arithmetics, remainders);
 
-criterion_main!(computation, arithmetics);
+criterion_main!(computation);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -125,4 +125,4 @@ fn remainders(c: &mut Criterion) {
 criterion_group!(computation, odd_product, triangle_number);
 criterion_group!(arithmetics, remainders);
 
-criterion_main!(computation);
+criterion_main!(computation, arithmetics);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -82,7 +82,7 @@ fn triangle_number(c: &mut Criterion) {
 }
 
 fn odd_product(c: &mut Criterion) {
-    let ns = [100_000i32, 200_000, 400_000, 800_000].map(|n| (n, n.to_string()));
+    let ns = [500_000, 1_000_000, 2_000_000].map(|n| (n, n.to_string()));
     let ns_evm = ns
         .clone()
         .map(|(n, display)| {


### PR DESCRIPTION
Finding the goldilocks `n`s which are not too big for EVM execution and not too small for `riscv` execution. For `riscv` small `n`s do not show meaningful increases in execution time because of the initialization overhead.

## Solidity

### odd_product

|               | `evm`                  | `solang(wasm)`                | `solang(riscv)`                    |
|:--------------|:-----------------------|:------------------------------|:---------------------------------- |
| **`2000000`** | `1.30 s` (✅ **1.00x**) | `1.68 s` (❌ *1.29x slower*)   | `50.79 ms` (🚀 **25.56x faster**)   |
| **`4000000`** | `2.61 s` (✅ **1.00x**) | `3.33 s` (❌ *1.27x slower*)   | `101.59 ms` (🚀 **25.69x faster**)  |
| **`8000000`** | `5.23 s` (✅ **1.00x**) | `6.63 s` (❌ *1.27x slower*)   | `200.37 ms` (🚀 **26.10x faster**)  |

### triangle_number

|                | `evm`                  | `solang(wasm)`                    | `solang(riscv)`                    |
|:---------------|:-----------------------|:----------------------------------|:---------------------------------- |
| **`3000000`**  | `1.42 s` (✅ **1.00x**) | `50.07 ms` (🚀 **28.41x faster**)  | `5.67 ms` (🚀 **250.78x faster**)   |
| **`6000000`**  | `2.90 s` (✅ **1.00x**) | `99.81 ms` (🚀 **29.01x faster**)  | `7.86 ms` (🚀 **368.19x faster**)   |
| **`12000000`** | `5.72 s` (✅ **1.00x**) | `199.26 ms` (🚀 **28.71x faster**) | `14.48 ms` (🚀 **395.20x faster**)  |

## ink!

### odd_product

|               | `ink(wasm)`               | `ink(riscv)`                      |
|:--------------|:--------------------------|:--------------------------------- |
| **`2000000`** | `58.08 ms` (✅ **1.00x**)  | `6.04 ms` (🚀 **9.61x faster**)    |
| **`4000000`** | `112.60 ms` (✅ **1.00x**) | `8.84 ms` (🚀 **12.73x faster**)   |
| **`8000000`** | `222.19 ms` (✅ **1.00x**) | `16.28 ms` (🚀 **13.65x faster**)  |

### triangle_number

|                | `ink(wasm)`               | `ink(riscv)`                      |
|:---------------|:--------------------------|:--------------------------------- |
| **`3000000`**  | `76.85 ms` (✅ **1.00x**)  | `6.33 ms` (🚀 **12.13x faster**)   |
| **`6000000`**  | `153.89 ms` (✅ **1.00x**) | `11.13 ms` (🚀 **13.82x faster**)  |
| **`12000000`** | `307.50 ms` (✅ **1.00x**) | `21.62 ms` (🚀 **14.22x faster**)  |

### sha3

|            | `ink(wasm)`               | `ink(riscv)`                      |
|:-----------|:--------------------------|:--------------------------------- |
| **`2000`** | `53.46 ms` (✅ **1.00x**)  | `6.70 ms` (🚀 **7.98x faster**)    |
| **`4000`** | `125.96 ms` (✅ **1.00x**) | `9.76 ms` (🚀 **12.91x faster**)   |
| **`8000`** | `216.48 ms` (✅ **1.00x**) | `18.72 ms` (🚀 **11.57x faster**)  |

