### PR TITLE
Add fibonacci benchmark contracts

### DIFF
--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -141,10 +141,10 @@ fn fibonacci(c: &mut Criterion) {
 
     for n in [128u32, 192, 256, 320] {
         let args_scale = [(n, format!("{n}"))];
-        bench_solang(&mut group, "FibonacciIterative", "fib", &args_scale);
-
         let args_evm = [(vec![DynSolValue::Uint(U256::from(n), 32)], format!("{n}"))];
+
         bench_evm(&mut group, "FibonacciIterative", "fib", &args_evm);
+        bench_solang(&mut group, "FibonacciIterative", "fib", &args_scale);
     }
 
     group.finish();
@@ -154,10 +154,10 @@ fn fibonacci(c: &mut Criterion) {
 
     for n in [128u32, 192, 256, 320] {
         let args_scale = [(n, format!("{n}"))];
-        bench_solang(&mut group, "FibonacciBinet", "fib", &args_scale);
-
         let args_evm = [(vec![DynSolValue::Uint(U256::from(n), 32)], format!("{n}"))];
+
         bench_evm(&mut group, "FibonacciBinet", "fib", &args_evm);
+        bench_solang(&mut group, "FibonacciBinet", "fib", &args_scale);
     }
 
     group.finish();

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -122,7 +122,35 @@ fn remainders(c: &mut Criterion) {
     group.finish()
 }
 
-criterion_group!(computation, odd_product, triangle_number);
+fn fibonacci(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fibonacci_iterative");
+    group.sample_size(20);
+
+    for n in [1u32, 128, 256] {
+        let args_scale = [(n, format!("{n}"))];
+        bench_solang(&mut group, "FibonacciIterative", "fib", &args_scale);
+
+        let args_evm = [(vec![DynSolValue::Uint(U256::from(n), 32)], format!("{n}"))];
+        bench_evm(&mut group, "FibonacciIterative", "fib", &args_evm);
+    }
+
+    group.finish();
+
+    let mut group = c.benchmark_group("fibonacci_binet");
+    group.sample_size(20);
+
+    for n in [1u32, 128, 256] {
+        let args_scale = [(n, format!("{n}"))];
+        bench_solang(&mut group, "FibonacciBinet", "fib", &args_scale);
+
+        let args_evm = [(vec![DynSolValue::Uint(U256::from(n), 32)], format!("{n}"))];
+        bench_evm(&mut group, "FibonacciBinet", "fib", &args_evm);
+    }
+
+    group.finish();
+}
+
+criterion_group!(computation, odd_product, triangle_number, fibonacci);
 criterion_group!(arithmetics, remainders);
 
 criterion_main!(computation, arithmetics);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -126,7 +126,7 @@ fn fibonacci(c: &mut Criterion) {
     let mut group = c.benchmark_group("fibonacci_iterative");
     group.sample_size(20);
 
-    for n in [1u32, 128, 256] {
+    for n in [128u32, 192, 256, 320] {
         let args_scale = [(n, format!("{n}"))];
         bench_solang(&mut group, "FibonacciIterative", "fib", &args_scale);
 
@@ -139,7 +139,7 @@ fn fibonacci(c: &mut Criterion) {
     let mut group = c.benchmark_group("fibonacci_binet");
     group.sample_size(20);
 
-    for n in [1u32, 128, 256] {
+    for n in [128u32, 192, 256, 320] {
         let args_scale = [(n, format!("{n}"))];
         bench_solang(&mut group, "FibonacciBinet", "fib", &args_scale);
 

--- a/contracts/solidity/FibonacciBinet.sol
+++ b/contracts/solidity/FibonacciBinet.sol
@@ -1,0 +1,31 @@
+// Source: https://medium.com/coinmonks/fibonacci-in-solidity-8477d907e22a
+
+contract FibonacciBinet {
+    function fib(uint32 n) public pure returns (uint a) {
+        if (n == 0) {
+            return 0;
+        }
+        uint32 h = n / 2;
+        uint32 mask = 1;
+        // find highest set bit in n
+        while (mask <= h) {
+            mask <<= 1;
+        }
+        mask >>= 1;
+        a = 1;
+        uint b = 1;
+        uint c;
+        while (mask > 0) {
+            c = a * a + b * b;
+            if (n & mask > 0) {
+                b = b * (b + 2 * a);
+                a = c;
+            } else {
+                a = a * (2 * b - a);
+                b = c;
+            }
+            mask >>= 1;
+        }
+        return a;
+    }
+}

--- a/contracts/solidity/FibonacciIterative.sol
+++ b/contracts/solidity/FibonacciIterative.sol
@@ -1,0 +1,16 @@
+contract FibonacciIterative {
+    function fib(uint32 n) public pure returns (uint b) {
+        if (n == 0) {
+            return 0;
+        }
+
+        uint a = 1;
+        b = 1;
+        for (uint32 i = 2; i < n; i++) {
+            uint c = a + b;
+            a = b;
+            b = c;
+        }
+        return b;
+    }
+}


### PR DESCRIPTION
Some more simple computation to compare against EVM.

Something seems to be off though:

```
fibonacci_iterative/solang(wasm)/1
                        time:   [7.3634 ms 8.8033 ms 9.8503 ms]
                        change: [-18.568% +0.0104% +24.282%] (p = 0.99 > 0.05)
                        No change in performance detected.
```

This can't be, `fib(1)` does not do much, and should certainly not take that long? 