### PR TITLE
Add baseline benchmarks that do nothing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nop"
+version = "0.1.0"
+dependencies = [
+ "ink",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5321,6 +5328,7 @@ dependencies = [
  "frame-system 4.0.0-dev (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "hex",
  "ink",
+ "nop",
  "pallet-balances 4.0.0-dev (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "pallet-evm",
  "pallet-timestamp 4.0.0-dev (git+https://github.com/paritytech/polkadot-sdk?branch=master)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ scale-info = { version = "2.9.0", default-features = false, features = ["derive"
 # ink! contracts
 crypto = { path = "./contracts/ink/crypto", features = ["ink-as-dependency"] }
 computation = { path = "./contracts/ink/computation", features = ["ink-as-dependency"] }
+nop = { path = "./contracts/ink/nop", features = ["ink-as-dependency"] }
 config = "0.13.4"
 
 [[bench]]

--- a/benches/ink.rs
+++ b/benches/ink.rs
@@ -54,5 +54,7 @@ ink_contract_bench!(
     [3_000_000, 6_000_000, 12_000_000]
 );
 
-criterion_group!(benches, sha3, odd_product, triangle_number);
+ink_contract_bench!(nop, Nop, NopRef, baseline, [0]);
+
+criterion_group!(benches, baseline, sha3, odd_product, triangle_number);
 criterion_main!(benches);

--- a/benches/solidity.rs
+++ b/benches/solidity.rs
@@ -122,7 +122,20 @@ fn remainders(c: &mut Criterion) {
     group.finish()
 }
 
-criterion_group!(computation, odd_product, triangle_number);
+fn baseline(c: &mut Criterion) {
+    let args_scale = [(0, "(0)".to_owned())];
+    let args_evm = [(vec![DynSolValue::Uint(U256::ZERO, 32)], "(1)".to_owned())];
+
+    let mut group = c.benchmark_group("baseline");
+    group.sample_size(20);
+
+    bench_evm(&mut group, "compile_test", "test", &args_evm);
+    bench_solang(&mut group, "compile_test", "test", &args_scale);
+
+    group.finish()
+}
+
+criterion_group!(computation, baseline, odd_product, triangle_number);
 criterion_group!(arithmetics, remainders);
 
 criterion_main!(computation, arithmetics);

--- a/contracts/ink/nop/Cargo.toml
+++ b/contracts/ink/nop/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nop"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { git = "https://github.com/paritytech/ink", branch = "at/riscv", package = "ink", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/contracts/ink/nop/lib.rs
+++ b/contracts/ink/nop/lib.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+pub mod nop {
+    #[ink(storage)]
+    pub struct Nop {}
+
+    impl Nop {
+        #[allow(clippy::new_without_default)]
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn baseline(&self, _param: u32) {}
+    }
+}

--- a/contracts/solidity/compile_test.sol
+++ b/contracts/solidity/compile_test.sol
@@ -1,3 +1,3 @@
 contract compile_test {
-    function test() public pure {}
+    function test(uint32 _param) public pure {}
 }


### PR DESCRIPTION
We should also benchmark some nop functions that do nothing in their message. This will tell the baseline for instantiating the contract, message dispatch, received value checking and decoding of the dummy parameter. So we can later deduct that 